### PR TITLE
Blunt fix for null references errors.

### DIFF
--- a/BrawlBox/UI/Model Previewer/ModelEditControl/Rendering.cs
+++ b/BrawlBox/UI/Model Previewer/ModelEditControl/Rendering.cs
@@ -222,8 +222,8 @@ namespace System.Windows.Forms
             List<MDL0BoneNode> ItemBones = new List<MDL0BoneNode>();
 
             //Get bones and render spawns if checked
-            if (_targetModel.Name.Contains("osition")) {stgPos = _targetModel; }
-            else  { stgPos = _targetModels.Find(x => x.Name.Contains("osition")); }
+            if (_targetModel != null && _targetModel.Name.Contains("osition")) {stgPos = _targetModel; }
+            else if (_targetModels != null) { stgPos = _targetModels.Find(x => x.Name.Contains("osition")); }
                 if(stgPos != null) foreach (MDL0BoneNode bone in stgPos._linker.BoneCache)
                 {
                     if (bone._name == "CamLimit0N") { CamBone0 = bone; }


### PR DESCRIPTION
I was seeing a NullReferenceError on the first line changed when previewing a model, closing the model editor, then repeating - on the third close it would throw the error.  (This was editing Project M's sc_selcharacter.pac > MiscData[30] > MenSelchrBack2_TopN, or MenSelchrFaceI_TopN - I didn't test any others.)

The second error (with _targetModels) would show up when the same thing was done, but would take between 2 and 7 iterations to crash.  It seemed to happen more consistently when editing was done - changing the animation for MenSelchrFaceI was what I was trying to do when I came across this.

Obviously this is a blunt fix; it would be better to learn why these are null sometimes.  I think _targetModels in particular should probably never be null, and things setting it to that should probably be making it be an empty list instead.
