### PR TITLE
Made pixel format conversions more accurate.

### DIFF
--- a/BrawlLib/Wii/Textures/I4.cs
+++ b/BrawlLib/Wii/Textures/I4.cs
@@ -55,16 +55,18 @@ namespace BrawlLib.Wii.Textures
             }
             set
             {
-                int c = (value.R + value.G + value.B) / 3;
-                _data = (index % 2 == 0) ? (byte)((c & 0xF0) | (_data & 0x0F)) : (byte)((c >> 4) | (_data & 0xF0));
+                int c = (value.R + value.G + value.B + 1) / 3;  // Extra 1 added to get effect of rounding to nearest instead of rounding down
+                c = Convert.ToInt32(c * (15.0 / 255.0));        // Convert from 8 bits to 4
+                _data = (index % 2 == 0) ? (byte)((c << 4) | (_data & 0x0F)) : (byte)(c | (_data & 0xF0));
             }
         }
 
 
         public static explicit operator I4Pixel(ARGBPixel p)
         {
-            int value = (p.R + p.G + p.B) / 3;
-            return new I4Pixel() { _data = (byte)((value >> 4) | (value & 0xF0)) };
+            int value = (p.R + p.G + p.B + 1) / 3;              // Extra 1 added to get effect of rounding to nearest instead of rounding down
+            value = Convert.ToInt32(value * (15.0 / 255.0));    // Convert from 8 bits to 4
+            return new I4Pixel() { _data = (byte)((value << 4) | value) };
         }
     }
 }

--- a/BrawlLib/Wii/Textures/I8.cs
+++ b/BrawlLib/Wii/Textures/I8.cs
@@ -50,7 +50,7 @@ namespace BrawlLib.Wii.Textures
         }
         public static explicit operator I8Pixel(ARGBPixel p)
         {
-            return new I8Pixel() { _value = (byte)((p.R + p.G + p.B) / 3) };
+            return new I8Pixel() { _value = (byte)((p.R + p.G + p.B + 1) / 3) };    // Extra 1 added to get effect of rounding to nearest instead of rounding down
         }
     }
 }

--- a/BrawlLib/Wii/Textures/IA4.cs
+++ b/BrawlLib/Wii/Textures/IA4.cs
@@ -58,7 +58,10 @@ namespace BrawlLib.Wii.Textures
         }
         public static implicit operator IA4Pixel(ARGBPixel p)
         {
-            return new IA4Pixel() { data = (byte)((((p.R + p.G + p.B) / 3) & 0xF0) | (p.A >> 4)) };
+            int intensity = (p.R + p.G + p.B + 1) / 3;                  // Extra 1 added to get effect of rounding to nearest instead of rounding down
+            intensity = Convert.ToInt32(intensity * (15.0 / 255.0));    // Convert intensity from 8 bits to 4
+            int alpha = Convert.ToInt32(p.A * (15.0 / 255.0));          // Convert alpha from 8 bits to 4
+            return new IA4Pixel() { data = (byte)((intensity << 4) | alpha) };
         }
     }
 }

--- a/BrawlLib/Wii/Textures/IA8.cs
+++ b/BrawlLib/Wii/Textures/IA8.cs
@@ -47,7 +47,7 @@ namespace BrawlLib.Wii.Textures
         }
         public static implicit operator IA8Pixel(ARGBPixel p)
         {
-            return new IA8Pixel() { intensity = (byte)((p.R + p.G + p.B) / 3), alpha = p.A };
+            return new IA8Pixel() { intensity = (byte)((p.R + p.G + p.B + 1) / 3), alpha = p.A };   // Extra 1 added to get effect of rounding to nearest instead of rounding down
         }
         public static explicit operator Color(IA8Pixel p)
         {
@@ -55,7 +55,7 @@ namespace BrawlLib.Wii.Textures
         }
         public static explicit operator IA8Pixel(Color p)
         {
-            return new IA8Pixel() { intensity = (byte)((p.R + p.G + p.B) / 3), alpha = p.A };
+            return new IA8Pixel() { intensity = (byte)((p.R + p.G + p.B + 1) / 3), alpha = p.A };   // Extra 1 added to get effect of rounding to nearest instead of rounding down
         }
     }
 }

--- a/BrawlLib/Wii/Textures/PixelTypes.cs
+++ b/BrawlLib/Wii/Textures/PixelTypes.cs
@@ -75,6 +75,13 @@ namespace BrawlLib.Wii.Textures
         public bushort _data;
 
         public wRGB565Pixel(bushort data) { _data = data; }
+        public wRGB565Pixel(int r, int g, int b)
+        {
+            r = Convert.ToInt32(r * (31.0 / 255.0));
+            g = Convert.ToInt32(g * (63.0 / 255.0));
+            b = Convert.ToInt32(b * (31.0 / 255.0));
+            _data = (ushort)((r << 11) | (g << 5) | b);
+        }
 
         public static bool operator >(wRGB565Pixel p1, wRGB565Pixel p2) { return (ushort)p1._data > (ushort)p2._data; }
         public static bool operator <(wRGB565Pixel p1, wRGB565Pixel p2) { return (ushort)p1._data < (ushort)p2._data; }
@@ -88,45 +95,38 @@ namespace BrawlLib.Wii.Textures
         {
             int r, g, b;
             ushort val = p._data;
-            r = (val & 0xF800); r = (r >> 8) | (r >> 13);
-            g = (val & 0x7E0); g = (g >> 3) | (g >> 9);
-            b = (val & 0x1F); b = (b << 3) | (b >> 2);
+            r = (val >> 11) & 0x1F; r = Convert.ToInt32(r * (255.0 / 31.0));
+            g = (val >> 5) & 0x3F; g = Convert.ToInt32(g * (255.0 / 63.0));
+            b = val & 0x1F; b = Convert.ToInt32(b * (255.0 / 31.0));
             return new ARGBPixel(0xFF, (byte)r, (byte)g, (byte)b);
         }
         public static explicit operator RGBPixel(wRGB565Pixel p)
         {
             int r, g, b;
             ushort val = p._data;
-            r = (val & 0xF800); r = (r >> 8) | (r >> 13);
-            g = (val & 0x7E0); g = (g >> 3) | (g >> 9);
-            b = (val & 0x1F); b = (b << 3) | (b >> 2);
+            r = (val >> 11) & 0x1F; r = Convert.ToInt32(r * (255.0 / 31.0));
+            g = (val >> 5) & 0x3F; g = Convert.ToInt32(g * (255.0 / 63.0));
+            b = val & 0x1F; b = Convert.ToInt32(b * (255.0 / 31.0));
             return new RGBPixel() { R = (byte)r, G = (byte)g, B = (byte)b };
-        }
-        public static explicit operator wRGB565Pixel(ARGBPixel p)
-        { return new wRGB565Pixel() { _data = (ushort)(((p.R >> 3) << 11) | ((p.G >> 2) << 5) | (p.B >> 3)) }; }
-        public static explicit operator wRGB565Pixel(RGBPixel p)
-        {
-            return new wRGB565Pixel() { _data = (ushort)(((p.R >> 3) << 11) | ((p.G >> 2) << 5) | (p.B >> 3)) };
-        }
-        public static explicit operator wRGB565Pixel(Color p)
-        {
-            return new wRGB565Pixel() { _data = (ushort)(((p.R >> 3) << 11) | ((p.G >> 2) << 5) | (p.B >> 3)) };
         }
         public static explicit operator Color(wRGB565Pixel p)
         {
             int r, g, b;
             ushort val = p._data;
-            r = val & 0xF800; r = (r >> 8) | (r >> 13);
-            g = (val & 0x7E0); g = (g >> 3) | (g >> 9);
-            b = (val & 0x1F); b = (b << 3) | (b >> 2);
+            r = (val >> 11) & 0x1F; r = Convert.ToInt32(r * (255.0 / 31.0));
+            g = (val >> 5) & 0x3F; g = Convert.ToInt32(g * (255.0 / 63.0));
+            b = val & 0x1F; b = Convert.ToInt32(b * (255.0 / 31.0));
             return Color.FromArgb(0xFF, r, g, b);
         }
+        public static explicit operator wRGB565Pixel(ARGBPixel p) { return new wRGB565Pixel(p.R, p.G, p.B); }
+        public static explicit operator wRGB565Pixel(RGBPixel p) { return new wRGB565Pixel(p.R, p.G, p.B); }
+        public static explicit operator wRGB565Pixel(Color p) { return new wRGB565Pixel(p.R, p.G, p.B); }
 
         public static explicit operator wRGB565Pixel(Vector3 v) 
         {
-            int r = Math.Max(Math.Min((int)(v._x * (31.0f + 0.5f)), 31), 0);
-            int g = Math.Max(Math.Min((int)(v._y * (63.0f + 0.5f)), 63), 0);
-            int b = Math.Max(Math.Min((int)(v._z * (31.0f + 0.5f)), 31), 0);
+            int r = Math.Max(Math.Min(Convert.ToInt32(v._x * 31.0f), 31), 0);
+            int g = Math.Max(Math.Min(Convert.ToInt32(v._y * 63.0f), 63), 0);
+            int b = Math.Max(Math.Min(Convert.ToInt32(v._z * 31.0f), 31), 0);
             return new wRGB565Pixel((ushort)((r << 11) | (g << 5) | b));
         }
 
@@ -145,6 +145,26 @@ namespace BrawlLib.Wii.Textures
     public struct wRGB5A3Pixel
     {
         public bushort _data;
+
+        public wRGB5A3Pixel(int a, int r, int g, int b)
+        {
+            a = Convert.ToInt32(a * (7.0 / 255.0));
+            if (a == 7)
+            {
+                r = Convert.ToInt32(r * (31.0 / 255.0));
+                g = Convert.ToInt32(g * (31.0 / 255.0));
+                b = Convert.ToInt32(b * (31.0 / 255.0));
+                _data = (ushort)((1 << 15) | (r << 10) | (g << 5) | b);
+            }
+            else
+            {
+                r = Convert.ToInt32(r * (15.0 / 255.0));
+                g = Convert.ToInt32(g * (15.0 / 255.0));
+                b = Convert.ToInt32(b * (15.0 / 255.0));
+                _data = (ushort)((a << 12) | (r << 8) | (g << 4) | b);
+            }
+        }
+
         public static explicit operator ARGBPixel(wRGB5A3Pixel p)
         {
             int a, r, g, b;
@@ -152,13 +172,13 @@ namespace BrawlLib.Wii.Textures
             if ((val & 0x8000) != 0)
             {
                 a = 0xFF;
-                r = val & 0x7C00; r = (r >> 7) | (r >> 12);
-                g = (val & 0x3E0); g = (g >> 2) | (g >> 7);
-                b = (val & 0x1F); b = (b << 3) | (b >> 2);
+                r = (val >> 10) & 0x1F; r = Convert.ToInt32(r * (255.0 / 31.0));
+                g = (val >> 5) & 0x1F; g = Convert.ToInt32(g * (255.0 / 31.0));
+                b = val & 0x1F; b = Convert.ToInt32(b * (255.0 / 31.0));
             }
             else
             {
-                a = val & 0x7000; a = (a >> 7) | (a >> 10) | (a >> 13);
+                a = (val >> 12) & 0x07; a = Convert.ToInt32(a * (255.0 / 7.0));
                 r = val & 0xF00; r = (r >> 4) | (r >> 8);
                 g = val & 0xF0; g |= (g >> 4);
                 b = val & 0x0F; b |= (b << 4);
@@ -167,8 +187,7 @@ namespace BrawlLib.Wii.Textures
         }
         public static explicit operator wRGB5A3Pixel(ARGBPixel p)
         {
-            if ((p.A & 0xE0) != 0xE0) return new wRGB5A3Pixel() { _data = (ushort)(((p.A >> 5) << 12) | ((p.R >> 4) << 8) | ((p.G >> 4) << 4) | (p.B >> 4)) };
-            else return new wRGB5A3Pixel() { _data = (ushort)(0x8000 | ((p.R >> 3) << 10) | ((p.G >> 3) << 5) | (p.B >> 3)) };
+            return new wRGB5A3Pixel(p.A, p.R, p.G, p.B);
         }
 
         public static explicit operator Color(wRGB5A3Pixel p)
@@ -178,13 +197,13 @@ namespace BrawlLib.Wii.Textures
             if ((val & 0x8000) != 0)
             {
                 a = 0xFF;
-                r = val & 0x7C00; r = (r >> 7) | (r >> 12);
-                g = (val & 0x3E0); g = (g >> 2) | (g >> 7);
-                b = (val & 0x1F); b = (b << 3) | (b >> 2);
+                r = (val >> 10) & 0x1F; r = Convert.ToInt32(r * (255.0 / 31.0));
+                g = (val >> 5) & 0x1F; g = Convert.ToInt32(g * (255.0 / 31.0));
+                b = val & 0x1F; b = Convert.ToInt32(b * (255.0 / 31.0));
             }
             else
             {
-                a = val & 0x7000; a = (a >> 7) | (a >> 10) | (a >> 13);
+                a = (val >> 12) & 0x07; a = Convert.ToInt32(a * (255.0 / 7.0));
                 r = val & 0xF00; r = (r >> 4) | (r >> 8);
                 g = val & 0xF0; g |= (g >> 4);
                 b = val & 0x0F; b |= (b << 4);
@@ -193,8 +212,7 @@ namespace BrawlLib.Wii.Textures
         }
         public static explicit operator wRGB5A3Pixel(Color p)
         {
-            if ((p.A & 0xE0) != 0xE0) return new wRGB5A3Pixel() { _data = (ushort)(((p.A >> 5) << 12) | ((p.R >> 4) << 8) | ((p.G >> 4) << 4) | (p.B >> 4)) };
-            else return new wRGB5A3Pixel() { _data = (ushort)(0x8000 | ((p.R >> 3) << 10) | ((p.G >> 3) << 5) | (p.B >> 3)) };
+            return new wRGB5A3Pixel(p.A, p.R, p.G, p.B);
         }
     }
 }


### PR DESCRIPTION
This change is about making converting a color from 8 bit to 6, 5, 4, or 3 bits, and vice versa, more accurate. (It also makes it slower, but that's not an issue for BrawlBox.)

Conversion from 4 bits to 8 remains the same - that should be a multiplication by 17, and that's what the implementation does, though bit manipulations.  Converting 8 bits to 4, conversely, should be done by dividing by 17 and rounding to the nearest integer, but was instead being done by dividing by 16 and rounding down.

In general, conversion is done by multiplying by the max value in the desired new bit depth, and dividing by the max value in the current bit depth.  I've used Convert.ToInt32 for the rounding and conversion from Float to Int.

For an example of how this improves things, here are three images of a CSP from Smash 3 - the original 32 bit depth version, one converted to RGB5A3 then exported after these changes, and one converted before these changes:
![zelda_00_csp](https://cloud.githubusercontent.com/assets/3161425/5235937/e4ae25a6-77cf-11e4-97c3-17972010be87.png)![zelda_00_csp updated brawlbox](https://cloud.githubusercontent.com/assets/3161425/5235938/ed84e6b0-77cf-11e4-8928-6f0dccc0d3c9.png)![zelda_00_csp original brawlbox conversion](https://cloud.githubusercontent.com/assets/3161425/5235939/f01c94d6-77cf-11e4-959f-b4ae2622ece8.png)
The most noticeable difference is that the white of the gloves is whiter after conversion without these changes. (That is much more obvious when switching between the two images being displayed in the same position than when looking at them side-by-side.)
