### PR TITLE
When linking BaseWrapper, make sure nodes end up in the correct order

### DIFF
--- a/BrawlBox/NodeWrappers/BaseWrapper.cs
+++ b/BrawlBox/NodeWrappers/BaseWrapper.cs
@@ -68,6 +68,9 @@ namespace BrawlBox
                             {
                                 tn.Link(n);
                                 found = true;
+                                // Move node to bottom, to ensure that nodes are shown and saved in the same order as in the original data
+                                nodes.Remove(tn);
+                                nodes.Add(tn);
                                 break;
                             }
 


### PR DESCRIPTION
I noticed that when I replace a node that has children, the new children whose names match old children will be above the ones whose names do not. In my case, it makes more sense to maintain the original ordering (this is for event match and all-star data, so ordering is important.) Does this break anything else?