### PR TITLE
Fix adpcm encoding to match Nintendo's implementation

### DIFF
--- a/BrawlLib/Wii/Audio/AudioConverter.cs
+++ b/BrawlLib/Wii/Audio/AudioConverter.cs
@@ -558,7 +558,7 @@ namespace BrawlLib.Wii.Audio
                     }
                 }
 
-                if (maxIndex == i)
+                if (maxIndex != i)
                 {
                     for (int y = 1; y <= 2; y++)
                     {


### PR DESCRIPTION
There was an error in the reverse engineering of this function, resulting in dirty sound. This is most easily noticeable when encoding a pure sine wave. This PR fixes that, resulting in the same output as Nintendo's encoder.