### PR TITLE
Various BRSTM encoding fixes/improvements

### DIFF
--- a/BrawlLib/SSBB/Types/Audio/RSTM.cs
+++ b/BrawlLib/SSBB/Types/Audio/RSTM.cs
@@ -80,7 +80,8 @@ namespace BrawlLib.SSBBTypes
             list = Part2;
             list->_numEntries._data = 1; //Number is little-endian
             list->Entries[0] = 0x58;
-            *(AudioFormatInfo*)list->Get(offset, 0) = new AudioFormatInfo(2, 0, 1, 0);
+            *(AudioFormatInfo*)list->Get(offset, 0) = 
+                channels == 1 ? new AudioFormatInfo(1, 0, 0, 0) : new AudioFormatInfo(2, 0, 1, 0);
 
             //Set adpcm infos
             list = Part3;

--- a/BrawlLib/SSBB/Types/Audio/RSTM.cs
+++ b/BrawlLib/SSBB/Types/Audio/RSTM.cs
@@ -227,17 +227,15 @@ namespace BrawlLib.SSBBTypes
 
         public uint _tag;
         public bint _length;
-        int _pad1, _pad2;
 
         public void Set(int length)
         {
             _tag = Tag;
             _length = length;
-            _pad1 = _pad2 = 0;
         }
 
         private VoidPtr Address { get { fixed (void* ptr = &this)return ptr; } }
-        public VoidPtr Data { get { return Address + 0x10; } }
+        public VoidPtr Data { get { return Address + 8; } }
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/BrawlLib/Wii/Audio/AudioConverter.cs
+++ b/BrawlLib/Wii/Audio/AudioConverter.cs
@@ -193,7 +193,7 @@ namespace BrawlLib.Wii.Audio
             int* buffer1 = stackalloc int[128];
             int* buffer2 = stackalloc int[112];
 
-            long bestDistance = long.MaxValue, distAccum;
+            double bestDistance = double.MaxValue, distAccum;
             int bestIndex = 0;
             int bestScale = 0;
 
@@ -219,7 +219,7 @@ namespace BrawlLib.Wii.Audio
                 for (int y = 0; y < samples; y++)
                 {
                     //Multiply previous samples by coefs
-                    *t1++ = v1 = ((*sPtr++ * coefs[1]) + (*sPtr++ * coefs[0])) >> 11;
+                    *t1++ = v1 = ((*sPtr++ * coefs[1]) + (*sPtr++ * coefs[0])) / 2048;
                     //Subtract from current sample
                     v2 = *sPtr-- - v1;
                     //Clamp
@@ -230,7 +230,7 @@ namespace BrawlLib.Wii.Audio
                 }
 
                 //Set initial scale
-                for (scale = 0; (scale <= 12) && ((distance > 7) || (distance < -8)); scale++, distance >>= 1) ;
+                for (scale = 0; (scale <= 12) && ((distance > 7) || (distance < -8)); scale++, distance /= 2) ;
                 scale = (scale <= 1) ? -1 : scale - 2;
 
                 do
@@ -274,11 +274,7 @@ namespace BrawlLib.Wii.Audio
                         *t1-- = v2 = (v1 >= 32767) ? 32767 : (v1 <= -32768) ? -32768 : v1;
                         //Accumulate distance
                         v3 = *sPtr++ - v2;
-                        distAccum += v3 * v3;
-
-                        //Break if we're higher than a previous search
-                        if (distAccum >= bestDistance)
-                            break;
+                        distAccum += (double)v3 * v3;
                     }
 
                     for (int x = index + 8; x > 256; x >>= 1)

--- a/BrawlLib/Wii/Audio/RSTMConverter.cs
+++ b/BrawlLib/Wii/Audio/RSTMConverter.cs
@@ -167,6 +167,12 @@ namespace BrawlLib.Wii.Audio
             //Encode blocks
             byte* dPtr = (byte*)data->Data;
             bshort* pyn = (bshort*)adpc->Data;
+            for (int x = 0; x < channels; x++)
+            {
+                *pyn++ = 0;
+                *pyn++ = 0;
+            }
+
             for (int sIndex = 0, bIndex = 1; sIndex < totalSamples; sIndex += 0x3800, bIndex++)
             {
                 int blockSamples = Math.Min(totalSamples - sIndex, 0x3800);


### PR DESCRIPTION
This PR will change the ADPCM encoder output to exactly match the output from Nintendo's DSP-ADPCM v2.3 encoder's non-SIMD implementation.

I also fixed the ADPC chunk and the track information when creating mono files.