### PR TITLE
Use OpenAL instead of DirectSound (unless library is not available)

### DIFF
--- a/BrawlBox/BrawlBox.csproj
+++ b/BrawlBox/BrawlBox.csproj
@@ -1032,7 +1032,9 @@ mkdir Python
 %25windir%25\system32\xcopy "$(SolutionDir)$(ProjectName)\Lib" "$(TargetDir)/Python" /Y /I /E
 %25windir%25\system32\xcopy "$(TargetDir)*.dll" "$(TargetDir)/Lib" /Y /I
 %25windir%25\system32\xcopy "$(TargetDir)*.dll" "$(TargetDir)/lib" /Y /I
+%25windir%25\system32\xcopy "$(TargetDir)*.dll.config" "$(TargetDir)/lib" /Y /I
 del *.dll
+del *.dll.config
 del updater.exe</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/BrawlLib/BrawlLib.csproj
+++ b/BrawlLib/BrawlLib.csproj
@@ -257,6 +257,8 @@
     <None Include="SSBB\Types\Wii U\FTEX.cs" />
     <None Include="SSBB\Types\Wii U\SARC.cs" />
     <Compile Include="System\AttributeInfo.cs" />
+    <Compile Include="System\Audio\alAudioProvider.cs" />
+    <Compile Include="System\Audio\alAudioBuffer.cs" />
     <Compile Include="System\Audio\WaveFormatTag.cs" />
     <Compile Include="System\Drawing\BitmapExtension.cs" />
     <Compile Include="System\Box.cs" />
@@ -310,9 +312,7 @@
     <Compile Include="OpenGL\TKContext.cs" />
     <Compile Include="OpenGL\GLCamera.cs" />
     <Compile Include="OpenGL\GLDisplayList.cs" />
-    <Compile Include="OpenGL\GLPanel.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
+    <Compile Include="OpenGL\GLPanel.cs" />
     <Compile Include="OpenGL\GLTexture.cs" />
     <Compile Include="OpenGL\IRenderedObject.cs" />
     <Compile Include="Platform\Win32.DirectSound.cs" />

--- a/BrawlLib/BrawlLib.csproj
+++ b/BrawlLib/BrawlLib.csproj
@@ -131,6 +131,9 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="OpenTK.dll.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="System\ComponentModel\CustomPropertyDescriptor.cs" />
     <None Include="System\ComponentModel\DelegatePropertyDescriptor.cs" />
     <Compile Include="Modeling\Collada\ColladaImportDialog.cs">

--- a/BrawlLib/OpenTK.dll.config
+++ b/BrawlLib/OpenTK.dll.config
@@ -1,0 +1,25 @@
+﻿<configuration>
+  <dllmap os="linux" dll="opengl32.dll" target="libGL.so.1"/>
+  <dllmap os="linux" dll="glu32.dll" target="libGLU.so.1"/>
+  <dllmap os="linux" dll="openal32.dll" target="libopenal.so.1"/>
+  <dllmap os="linux" dll="alut.dll" target="libalut.so.0"/>
+  <dllmap os="linux" dll="opencl.dll" target="libOpenCL.so"/>
+  <dllmap os="linux" dll="libX11" target="libX11.so.6"/>
+  <dllmap os="linux" dll="libXi" target="libXi.so.6"/>
+  <dllmap os="linux" dll="SDL2.dll" target="libSDL2-2.0.so.0"/>
+  <dllmap os="osx" dll="opengl32.dll" target="/System/Library/Frameworks/OpenGL.framework/OpenGL"/>
+  <dllmap os="osx" dll="openal32.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="alut.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="libGLES.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv1_CM.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv2.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="opencl.dll" target="/System/Library/Frameworks/OpenCL.framework/OpenCL"/>
+  <dllmap os="osx" dll="SDL2.dll" target="libSDL2.dylib"/>
+  <!-- XQuartz compatibility (X11 on Mac) -->
+  <dllmap os="osx" dll="libGL.so.1" target="/usr/X11/lib/libGL.dylib"/>
+  <dllmap os="osx" dll="libX11" target="/usr/X11/lib/libX11.dylib"/>
+  <dllmap os="osx" dll="libXcursor.so.1" target="/usr/X11/lib/libXcursor.dylib"/>
+  <dllmap os="osx" dll="libXi" target="/usr/X11/lib/libXi.dylib"/>
+  <dllmap os="osx" dll="libXinerama" target="/usr/X11/lib/libXinerama.dylib"/>
+  <dllmap os="osx" dll="libXrandr.so.2" target="/usr/X11/lib/libXrandr.dylib"/>
+</configuration>

--- a/BrawlLib/System/Audio/AudioProvider.cs
+++ b/BrawlLib/System/Audio/AudioProvider.cs
@@ -13,6 +13,16 @@ namespace System.Audio
 
         public static AudioProvider Create(AudioDevice device)
         {
+            if (device == null)
+            {
+                try
+                {
+                    var ap = new alAudioProvider();
+                    return ap;
+                }
+                catch (TypeInitializationException) { }
+            }
+
             switch (Environment.OSVersion.Platform)
             {
                 case PlatformID.Win32NT: return new wAudioProvider(device);

--- a/BrawlLib/System/Audio/alAudioBuffer.cs
+++ b/BrawlLib/System/Audio/alAudioBuffer.cs
@@ -1,0 +1,126 @@
+﻿using OpenTK.Audio.OpenAL;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace System.Audio
+{
+    unsafe class alAudioBuffer : AudioBuffer
+    {
+        alAudioProvider _parent;
+        int source;
+        List<int> buffers;
+
+        internal override int PlayCursor
+        {
+            get { int v; AL.GetSource((uint)source, ALGetSourcei.SampleOffset, out v); return v; }
+            set { AL.Source((uint)source, ALSourcei.SampleOffset, value); }
+        }
+        public override int Volume
+        {
+            get { return 0; }
+            set { }
+        }
+        public override int Pan
+        {
+            get { return 0; }
+            set { }
+        }
+        
+        internal alAudioBuffer(alAudioProvider parent, WaveFormatEx fmt)
+        {
+            _parent = parent;
+
+            buffers = new List<int>();
+
+            int size = DefaultBufferSpan * (int)fmt.nSamplesPerSec * fmt.nChannels * fmt.wBitsPerSample / 8;
+            if (size == 0)
+                return;
+
+            _format = fmt.wFormatTag;
+            _frequency = (int)fmt.nSamplesPerSec;
+            _channels = fmt.nChannels;
+            _bitsPerSample = fmt.wBitsPerSample;
+            _dataLength = size;
+            _blockAlign = _bitsPerSample * _channels / 8;
+            _sampleLength = _dataLength / _blockAlign;
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
+
+        public override BufferData Lock(int offset, int length)
+        {
+            BufferData data = new BufferData();
+
+            offset = offset.Align(_blockAlign);
+            length = length.Align(_blockAlign);
+            
+            data._dataOffset = offset;
+            data._dataLength = length;
+            data._sampleOffset = offset / _blockAlign;
+            data._sampleLength = length / _blockAlign;
+
+            if (length != 0)
+            {
+                IntPtr audioData = Marshal.AllocHGlobal(length);
+
+                data._part1Address = audioData;
+                data._part1Length = length;
+                data._part1Samples = length / _blockAlign;
+
+                data._part2Address = IntPtr.Zero;
+                data._part2Length = 0;
+                data._part2Samples = 0;
+            }
+            
+            return data;
+        }
+        public override void Unlock(BufferData data)
+        {
+            int buffer = AL.GenBuffer();
+            AL.BufferData(buffer, GetSoundFormat(_channels, _bitsPerSample), data.Part1Address, data.Part1Length, _frequency);
+            if (source != 0)
+            {
+                AL.SourceQueueBuffer(source, buffer);
+            }
+            else
+            {
+                lock (buffers)
+                {
+                    buffers.Add(buffer);
+                }
+            }
+            Marshal.FreeHGlobal(data.Part1Address);
+        }
+
+        public static ALFormat GetSoundFormat(int channels, int bits)
+        {
+            switch (channels)
+            {
+                case 1: return bits == 8 ? ALFormat.Mono8 : ALFormat.Mono16;
+                case 2: return bits == 8 ? ALFormat.Stereo8 : ALFormat.Stereo16;
+                default: throw new NotSupportedException("The specified sound format is not supported.");
+            }
+        }
+        
+        public override void Play()
+        {
+            source = AL.GenSource();
+            lock (buffers)
+            {
+                foreach (int buffer in buffers)
+                    AL.SourceQueueBuffer(source, buffer);
+                buffers.Clear();
+            }
+            AL.SourcePlay(source);
+        }
+        public override void Stop() 
+        {
+            AL.SourceStop(source);
+            AL.DeleteSource(source);
+            source = 0;
+        }
+    }
+}

--- a/BrawlLib/System/Audio/alAudioProvider.cs
+++ b/BrawlLib/System/Audio/alAudioProvider.cs
@@ -1,0 +1,33 @@
+﻿using System.Windows.Forms;
+using System.Runtime.InteropServices;
+using OpenTK.Audio;
+
+namespace System.Audio
+{
+    unsafe class alAudioProvider : AudioProvider
+    {
+        private AudioContext context;
+
+        internal alAudioProvider()
+        {
+            context = new AudioContext();
+        }
+        public override void Dispose()
+        {
+            base.Dispose();
+            context.Dispose();
+            context = null;
+        }
+
+        public override void Attach(Control owner) { }
+
+        public override AudioBuffer CreateBuffer(IAudioStream target)
+        {
+            int size = AudioBuffer.DefaultBufferSpan * target.Frequency * target.Channels * target.BitsPerSample / 8;
+
+            WaveFormatEx fmt = new WaveFormatEx(target.Format, target.Channels, target.Frequency, target.BitsPerSample);
+
+            return new alAudioBuffer(this, fmt) { _source = target, _owner = this };
+        }
+    }
+}

--- a/BrawlLib/System/Audio/alAudioProvider.cs
+++ b/BrawlLib/System/Audio/alAudioProvider.cs
@@ -15,7 +15,7 @@ namespace System.Audio
         public override void Dispose()
         {
             base.Dispose();
-            context.Dispose();
+            if (context != null) context.Dispose();
             context = null;
         }
 


### PR DESCRIPTION
This adds support for OpenAL as the audio backend. Works well playing .brstms on Ubuntu + Mono, with and without using Wine.

It will also use OpenAL on Windows if it can find an openal32.dll (like [this one](http://kcat.strangesoft.net/openal.html).)

Not tested with macOS, BSD, etc., but there was no audio support there previously anyway.

I'll give you all (Sammi and BJ96) the opportunity to look at this but I'll merge it after a couple of days if I don't hear anything.