### PR TITLE
EditAllDialog: Make CHR0 Default Scale value "1"

### DIFF
--- a/BrawlLib/System/Windows/Controls/EditAllDialog/CHR0.cs
+++ b/BrawlLib/System/Windows/Controls/EditAllDialog/CHR0.cs
@@ -599,7 +599,7 @@ namespace System.Windows.Forms
             this.ScaleZ.Name = "ScaleZ";
             this.ScaleZ.Size = new System.Drawing.Size(96, 20);
             this.ScaleZ.TabIndex = 14;
-            this.ScaleZ.Text = "0";
+            this.ScaleZ.Text = "1";
             // 
             // ScaleY
             // 
@@ -608,7 +608,7 @@ namespace System.Windows.Forms
             this.ScaleY.Name = "ScaleY";
             this.ScaleY.Size = new System.Drawing.Size(96, 20);
             this.ScaleY.TabIndex = 13;
-            this.ScaleY.Text = "0";
+            this.ScaleY.Text = "1";
             // 
             // ScaleX
             // 
@@ -617,7 +617,7 @@ namespace System.Windows.Forms
             this.ScaleX.Name = "ScaleX";
             this.ScaleX.Size = new System.Drawing.Size(96, 20);
             this.ScaleX.TabIndex = 12;
-            this.ScaleX.Text = "0";
+            this.ScaleX.Text = "1";
             // 
             // keyframeCopy
             // 


### PR DESCRIPTION
The default CHR0 scale values were previously set to (0,0,0). As shown in the attached image, I propose changing the default values to (1,1,1) so a user doesn't unintentionally scale planes by a factor of 0.
	
This is also my first pull request so please tell me if something isn't correct.

![capture11](https://cloud.githubusercontent.com/assets/17330088/20509613/de409120-b037-11e6-854b-4ae17d68bf59.PNG)

