### PR TITLE
Remove unused variables

### DIFF
--- a/BrawlLib/Imaging/GIF/AnimatedGifEncoder.cs
+++ b/BrawlLib/Imaging/GIF/AnimatedGifEncoder.cs
@@ -168,7 +168,7 @@ namespace Gif.Components
 				WritePixels(); // encode and write pixel data
 				firstFrame = false;
 			} 
-			catch (IOException e) 
+			catch (IOException) 
 			{
 				ok = false;
 			}
@@ -195,7 +195,7 @@ namespace Gif.Components
 					fs.Close();
 				}
 			} 
-			catch (IOException e) 
+			catch (IOException) 
 			{
 				ok = false;
 			}
@@ -277,7 +277,7 @@ namespace Gif.Components
 			{
 				WriteString("GIF89a"); // header
 			} 
-			catch (IOException e) 
+			catch (IOException) 
 			{
 				ok = false;
 			}
@@ -300,7 +300,7 @@ namespace Gif.Components
 				ok = Start(fs);
 				closeStream = true;
 			} 
-			catch (IOException e) 
+			catch (IOException) 
 			{
 				ok = false;
 			}

--- a/BrawlLib/Imaging/GIF/GifDecoder.cs
+++ b/BrawlLib/Imaging/GIF/GifDecoder.cs
@@ -390,7 +390,7 @@ namespace Gif.Components
 				name = name.Trim().ToLower();
 				status = Read( new FileInfo( name ).OpenRead() );
 			} 
-			catch (IOException e) 
+			catch (IOException) 
 			{
 				status = STATUS_OPEN_ERROR;
 			}
@@ -584,7 +584,7 @@ namespace Gif.Components
 			{
 				curByte = inStream.ReadByte();
 			} 
-			catch (IOException e) 
+			catch (IOException) 
 			{
 				status = STATUS_FORMAT_ERROR;
 			}
@@ -613,7 +613,7 @@ namespace Gif.Components
 						n += count;
 					}
 				} 
-				catch (IOException e) 
+				catch (IOException) 
 				{
 				}
 
@@ -641,7 +641,7 @@ namespace Gif.Components
 			{
 				n = inStream.Read(c, 0, c.Length );
 			} 
-			catch (IOException e) 
+			catch (IOException) 
 			{
 			}
 			if (n < nbytes) 

--- a/BrawlLib/Imaging/GIF/NeuQuant.cs
+++ b/BrawlLib/Imaging/GIF/NeuQuant.cs
@@ -428,7 +428,7 @@ namespace Gif.Components
 						p[1] -= (a * (p[1] - g)) / alpharadbias;
 						p[2] -= (a * (p[2] - r)) / alpharadbias;
 					} 
-					catch (Exception e) 
+					catch (Exception) 
 					{
 					} // prevents 1.3 miscompilation
 				}
@@ -441,7 +441,7 @@ namespace Gif.Components
 						p[1] -= (a * (p[1] - g)) / alpharadbias;
 						p[2] -= (a * (p[2] - r)) / alpharadbias;
 					} 
-					catch (Exception e) 
+					catch (Exception) 
 					{
 					}
 				}

--- a/BrawlLib/SSBB/ResourceNodes/ResourceNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/ResourceNode.cs
@@ -667,7 +667,7 @@ namespace BrawlLib.SSBB.ResourceNodes
                     Compressor.Compact(_compression, uncompMap.Address, uncompMap.Length, stream, this);
                     _replSrc = new DataSource(FileMap.FromStreamInternal(stream, FileMapProtect.Read, 0, (int)stream.Length), _compression);
                 }
-                catch (Exception x) { stream.Dispose(); throw; }
+                catch (Exception) { stream.Dispose(); throw; }
             }
         }
 

--- a/BrawlLib/System/IO/FileMap.cs
+++ b/BrawlLib/System/IO/FileMap.cs
@@ -48,7 +48,7 @@ namespace BrawlLib.IO
                 stream = new FileStream(tempPath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, options | FileOptions.DeleteOnClose);
             }
             try { map = FromStreamInternal(stream, prot, offset, length); }
-            catch (Exception x) { stream.Dispose(); throw; }
+            catch (Exception) { stream.Dispose(); throw; }
             map._path = path; //In case we're using a temp file
             return map;
         }
@@ -61,7 +61,7 @@ namespace BrawlLib.IO
         {
             FileStream stream = new FileStream(path = Path.GetTempFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 8, FileOptions.RandomAccess | FileOptions.DeleteOnClose);
             try { return FromStreamInternal(stream, FileMapProtect.ReadWrite, 0, length); }
-            catch (Exception x) { stream.Dispose(); throw; }
+            catch (Exception) { stream.Dispose(); throw; }
         }
 
         public static FileMap FromStream(FileStream stream) { return FromStream(stream, FileMapProtect.ReadWrite, 0, 0); }

--- a/BrawlLib/Wii/Textures/TextureConverter.cs
+++ b/BrawlLib/Wii/Textures/TextureConverter.cs
@@ -351,7 +351,7 @@ namespace BrawlLib.Wii.Textures
                 EncodePalette(fileView.Address + 0x40, pal, format);
                 return fileView;
             }
-            catch (Exception x)
+            catch (Exception)
             {
                 fileView.Dispose();
                 throw;
@@ -373,7 +373,7 @@ namespace BrawlLib.Wii.Textures
                 EncodePalette(fileView.Address + 0xC, pal, format);
                 return fileView;
             }
-            catch (Exception x)
+            catch (Exception)
             {
                 fileView.Dispose();
                 throw;
@@ -390,7 +390,7 @@ namespace BrawlLib.Wii.Textures
                 EncodePalette(fileView.Address, pal, format);
                 return fileView;
             }
-            catch (Exception x)
+            catch (Exception)
             {
                 fileView.Dispose();
                 throw;


### PR DESCRIPTION
Resolves all instances of: CS0168  C# The variable is declared but never used

I'm not sure what I'm doing in Visual Studio but I may as well try tidying up some of the warnings.