### PR TITLE
Fix inconsistent whitespace in Example (tex0 export).py

### DIFF
--- a/BrawlBox/Plugins/Example (tex0 export).py
+++ b/BrawlBox/Plugins/Example (tex0 export).py
@@ -12,8 +12,8 @@ def tex_search(node): #Recursive function to scan for all TEX0 nodes in the file
 if bboxapi.RootNode != None:
     root = bboxapi.RootNode
     for item in tex_search(root):
-	    print item.Name
-	    item.Export(item.Name + ".png") #We already know everything in this list is a TEX0, so we can export it to a #PNG
+        print item.Name
+        item.Export(item.Name + ".png") #We already know everything in this list is a TEX0, so we can export it to a #PNG
     print("    Done!")
 else:
     bboxapi.ShowMessage('Cannot find Root Node (is a file open?)','Error')


### PR DESCRIPTION
Fixes two "inconsistent whitespace" warnings