### PR TITLE
 Wright all MaterialRef Nodes

### DIFF
--- a/BrawlLib/Modeling/Collada/ColladaExporter.cs
+++ b/BrawlLib/Modeling/Collada/ColladaExporter.cs
@@ -174,8 +174,7 @@ namespace BrawlLib.Modeling
                     {
                         if (mat.Children.Count > 0)
                         {
-                            MDL0MaterialRefNode mr = mat.Children[0] as MDL0MaterialRefNode;
-                            if (mr._texture != null)
+                            foreach (MDL0MaterialRefNode mr in mat.Children)
                             {
                                 writer.WriteStartElement("newparam");
                                 writer.WriteAttributeString("sid", mr._texture.Name + "-surface");


### PR DESCRIPTION
For material nodes with more than one reference node, brawlbox will now wright the data for all of the reference nodes in separate newparam tags. importing a collada file with newparams for more than one reference node dosent work, but is harmless. brawlbox only imports with the first reference node that it finds.