### PR TITLE
Improve Export All functionality

### DIFF
--- a/BrawlBox/NodeWrappers/Archives/U8FolderWrapper.cs
+++ b/BrawlBox/NodeWrappers/Archives/U8FolderWrapper.cs
@@ -241,10 +241,87 @@ namespace BrawlBox.NodeWrappers
             if (path == null)
                 return;
 
-            ExportAllFormatDialog dialog = new ExportAllFormatDialog();
+            bool hasModels = false;
+            bool hasTextures = false;
+            foreach (ResourceNode r in _resource.Children)
+            {
+                if (hasModels && hasTextures)
+                    break;
+                if (r is BRRESNode)
+                {
+                    foreach (BRESGroupNode e in r.Children)
+                    {
+                        if (e.Type == BRESGroupNode.BRESGroupType.Textures)
+                            hasTextures = true;
+                        else if (e.Type == BRESGroupNode.BRESGroupType.Models)
+                            hasModels = true;
+                        if (hasModels && hasTextures)
+                            break;
+                    }
+                }
+                else if (r is U8FolderNode)
+                {
+                    bool hasModelsTemp = false;
+                    bool hasTexturesTemp = false;
+                    searchU8Folder((U8FolderNode)r, out hasModelsTemp, out hasTexturesTemp);
+                    hasModels = (hasModels || hasModelsTemp);
+                    hasTextures = (hasTextures || hasTexturesTemp);
+                }
+            }
 
-            if (dialog.ShowDialog() == DialogResult.OK)
-                ((BRRESNode)_resource).ExportToFolder(path, dialog.SelectedExtension);
+            string extensionTEX0 = ".tex0";
+            string extensionMDL0 = ".mdl0";
+
+            if (hasTextures)
+            {
+                ExportAllFormatDialog dialog = new ExportAllFormatDialog();
+
+                if (dialog.ShowDialog() == DialogResult.OK)
+                    extensionTEX0 = dialog.SelectedExtension;
+                else
+                    return;
+            }
+            if (hasModels)
+            {
+                ExportAllFormatDialog dialog = new ExportAllFormatDialog(true);
+
+                if (dialog.ShowDialog() == DialogResult.OK)
+                    extensionMDL0 = dialog.SelectedExtension;
+                else
+                    return;
+            }
+            ((U8FolderNode)_resource).ExportToFolder(path, extensionTEX0, extensionMDL0);
+        }
+
+        public void searchU8Folder(U8FolderNode u8, out bool hasModels, out bool hasTextures)
+        {
+            hasModels = false;
+            hasTextures = false;
+            foreach (ResourceNode r in u8.Children)
+            {
+                if (hasModels && hasTextures)
+                    break;
+                if (r is BRRESNode)
+                {
+                    foreach (BRESGroupNode e in r.Children)
+                    {
+                        if (e.Type == BRESGroupNode.BRESGroupType.Textures)
+                            hasTextures = true;
+                        else if (e.Type == BRESGroupNode.BRESGroupType.Models)
+                            hasModels = true;
+                        if (hasModels && hasTextures)
+                            break;
+                    }
+                }
+                else if (r is U8FolderNode)
+                {
+                    bool hasModelsTemp = false;
+                    bool hasTexturesTemp = false;
+                    searchU8Folder((U8FolderNode)r, out hasModelsTemp, out hasTexturesTemp);
+                    hasModels = (hasModels || hasModelsTemp);
+                    hasTextures = (hasTextures || hasTexturesTemp);
+                }
+            }
         }
 
         public void EditAll()

--- a/BrawlBox/NodeWrappers/Archives/U8Wrapper.cs
+++ b/BrawlBox/NodeWrappers/Archives/U8Wrapper.cs
@@ -161,7 +161,87 @@ namespace BrawlBox.NodeWrappers
             if (path == null)
                 return;
 
-            ((ARCNode)_resource).ExtractToFolder(path);
+            bool hasModels = false;
+            bool hasTextures = false;
+            foreach (ResourceNode r in _resource.Children)
+            {
+                if (hasModels && hasTextures)
+                    break;
+                if (r is BRRESNode)
+                {
+                    foreach (BRESGroupNode e in r.Children)
+                    {
+                        if (e.Type == BRESGroupNode.BRESGroupType.Textures)
+                            hasTextures = true;
+                        else if (e.Type == BRESGroupNode.BRESGroupType.Models)
+                            hasModels = true;
+                        if (hasModels && hasTextures)
+                            break;
+                    }
+                }
+                else if (r is U8FolderNode)
+                {
+                    bool hasModelsTemp = false;
+                    bool hasTexturesTemp = false;
+                    searchU8Folder((U8FolderNode)r, out hasModelsTemp, out hasTexturesTemp);
+                    hasModels = (hasModels || hasModelsTemp);
+                    hasTextures = (hasTextures || hasTexturesTemp);
+                }
+            }
+
+            string extensionTEX0 = ".tex0";
+            string extensionMDL0 = ".mdl0";
+
+            if (hasTextures)
+            {
+                ExportAllFormatDialog dialog = new ExportAllFormatDialog();
+
+                if (dialog.ShowDialog() == DialogResult.OK)
+                    extensionTEX0 = dialog.SelectedExtension;
+                else
+                    return;
+            }
+            if (hasModels)
+            {
+                ExportAllFormatDialog dialog = new ExportAllFormatDialog(true);
+
+                if (dialog.ShowDialog() == DialogResult.OK)
+                    extensionMDL0 = dialog.SelectedExtension;
+                else
+                    return;
+            }
+            ((U8Node)_resource).ExtractToFolder(path, extensionTEX0, extensionMDL0);
+        }
+
+        public void searchU8Folder(U8FolderNode u8, out bool hasModels, out bool hasTextures)
+        {
+            hasModels = false;
+            hasTextures = false;
+            foreach (ResourceNode r in u8.Children)
+            {
+                if (hasModels && hasTextures)
+                    break;
+                if (r is BRRESNode)
+                {
+                    foreach (BRESGroupNode e in r.Children)
+                    {
+                        if (e.Type == BRESGroupNode.BRESGroupType.Textures)
+                            hasTextures = true;
+                        else if (e.Type == BRESGroupNode.BRESGroupType.Models)
+                            hasModels = true;
+                        if (hasModels && hasTextures)
+                            break;
+                    }
+                }
+                else if (r is U8FolderNode)
+                {
+                    bool hasModelsTemp = false;
+                    bool hasTexturesTemp = false;
+                    searchU8Folder((U8FolderNode)r, out hasModelsTemp, out hasTexturesTemp);
+                    hasModels = (hasModels || hasModelsTemp);
+                    hasTextures = (hasTextures || hasTexturesTemp);
+                }
+            }
         }
 
         public void ReplaceAll()

--- a/BrawlLib/SSBB/ResourceNodes/Archives/ARCNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Archives/ARCNode.cs
@@ -61,7 +61,9 @@ namespace BrawlLib.SSBB.ResourceNodes
             return Header->_numFiles > 0;
         }
 
-        public void ExtractToFolder(string outFolder)
+        public void ExtractToFolder(string outFolder) { ExtractToFolder(outFolder, ".tex0", ".mdl0"); }
+        public void ExtractToFolder(string outFolder, string imageExtension) { ExtractToFolder(outFolder, imageExtension, ".mdl0"); }
+        public void ExtractToFolder(string outFolder, string imageExtension, string modelExtension)
         {
             if (!Directory.Exists(outFolder))
                 Directory.CreateDirectory(outFolder);
@@ -69,9 +71,9 @@ namespace BrawlLib.SSBB.ResourceNodes
             List<string> directChildrenExportedPaths = new List<string>();
             foreach (ARCEntryNode entry in Children)
                 if (entry is ARCNode)
-                    ((ARCNode)entry).ExtractToFolder(Path.Combine(outFolder, entry.Name));
+                    ((ARCNode)entry).ExtractToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
                 else if (entry is BRRESNode)
-                    ((BRRESNode)entry).ExportToFolder(Path.Combine(outFolder, entry.Name));
+                    ((BRRESNode)entry).ExportToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
                 else
                 {
                     if (entry.WorkingSource.Length == 0)

--- a/BrawlLib/SSBB/ResourceNodes/Archives/BRRESNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Archives/BRRESNode.cs
@@ -125,18 +125,21 @@ namespace BrawlLib.SSBB.ResourceNodes
             return n;
         }
         public void ExportToFolder(string outFolder) { ExportToFolder(outFolder, ".tex0"); }
-        public void ExportToFolder(string outFolder, string imageExtension)
+        public void ExportToFolder(string outFolder, string imageExtension) { ExportToFolder(outFolder, imageExtension, ".mdl0"); }
+        public void ExportToFolder(string outFolder, string imageExtension, string modelExtension)
         {
             if (!Directory.Exists(outFolder))
                 Directory.CreateDirectory(outFolder);
 
             string ext = "";
+            bool extract = true;
             foreach (BRESGroupNode group in Children)
             {
+                extract = true;
                 if (group.Type == BRESGroupNode.BRESGroupType.Textures)
                     ext = imageExtension;
                 else if (group.Type == BRESGroupNode.BRESGroupType.Models)
-                    ext = ".mdl0";
+                    ext = modelExtension;
                 else if (group.Type == BRESGroupNode.BRESGroupType.CHR0)
                     ext = ".chr0";
                 else if (group.Type == BRESGroupNode.BRESGroupType.CLR0)
@@ -152,9 +155,16 @@ namespace BrawlLib.SSBB.ResourceNodes
                 else if (group.Type == BRESGroupNode.BRESGroupType.SCN0)
                     ext = ".scn0";
                 else if (group.Type == BRESGroupNode.BRESGroupType.Palettes)
+                {
                     ext = ".plt0";
-                foreach (BRESEntryNode entry in group.Children)
-                    entry.Export(Path.Combine(outFolder, entry.Name + ext));
+                    if (imageExtension != ".tex0")
+                        extract = false;
+                }
+                else
+                    extract = false;
+                if (extract)
+                    foreach (BRESEntryNode entry in group.Children)
+                        entry.Export(Path.Combine(outFolder, entry.Name + ext));
             }
         }
         public void ReplaceFromFolder(string inFolder) { ReplaceFromFolder(inFolder, ".tex0"); }

--- a/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
+++ b/BrawlLib/SSBB/ResourceNodes/Archives/U8Node.cs
@@ -233,6 +233,43 @@ namespace BrawlLib.SSBB.ResourceNodes
         {
             return ((U8*)source.Address)->_tag == U8.Tag ? new U8Node() : null;
         }
+        
+        public void ExtractToFolder(string outFolder) { ExtractToFolder(outFolder, ".tex0", ".mdl0"); }
+        public void ExtractToFolder(string outFolder, string imageExtension) { ExtractToFolder(outFolder, imageExtension, ".mdl0"); }
+        public void ExtractToFolder(string outFolder, string imageExtension, string modelExtension)
+        {
+            if (!Directory.Exists(outFolder))
+                Directory.CreateDirectory(outFolder);
+
+            List<string> directChildrenExportedPaths = new List<string>();
+            foreach (ResourceNode entry in Children)
+            {
+                if (entry is ARCNode)
+                    ((ARCNode)entry).ExtractToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else if (entry is BRRESNode)
+                    ((BRRESNode)entry).ExportToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else if (entry is U8Node)
+                    ((U8Node)entry).ExtractToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else if (entry is U8FolderNode)
+                    ((U8FolderNode)entry).ExportToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else
+                {
+                    if (entry.WorkingSource.Length == 0)
+                        continue;
+
+                    string ext = FileFilters.GetDefaultExportAllExtension(entry.GetType());
+                    string path = Path.Combine(outFolder, entry.Name + ext);
+
+                    if (directChildrenExportedPaths.Contains(path))
+                        throw new Exception($"There is more than one node underneath {this.Name} with the name {entry.Name}.");
+                    else
+                    {
+                        directChildrenExportedPaths.Add(path);
+                        entry.Export(path);
+                    }
+                }
+            }
+        }
     }
     public unsafe class U8EntryNode : ResourceNode
     {
@@ -283,6 +320,43 @@ namespace BrawlLib.SSBB.ResourceNodes
             AddChild(n);
 
             return n;
+        }
+
+        public void ExportToFolder(string outFolder) { ExportToFolder(outFolder, ".tex0"); }
+        public void ExportToFolder(string outFolder, string imageExtension) { ExportToFolder(outFolder, imageExtension, ".mdl0"); }
+        public void ExportToFolder(string outFolder, string imageExtension, string modelExtension)
+        {
+            if (!Directory.Exists(outFolder))
+                Directory.CreateDirectory(outFolder);
+
+            List<string> directChildrenExportedPaths = new List<string>();
+            foreach (ResourceNode entry in Children)
+            {
+                if (entry is ARCNode)
+                    ((ARCNode)entry).ExtractToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else if (entry is BRRESNode)
+                    ((BRRESNode)entry).ExportToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else if (entry is U8Node)
+                    ((U8Node)entry).ExtractToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else if (entry is U8FolderNode)
+                    ((U8FolderNode)entry).ExportToFolder(Path.Combine(outFolder, (entry.Name == null || entry.Name.Contains("<Null>", StringComparison.InvariantCultureIgnoreCase)) ? "Null" : entry.Name), imageExtension, modelExtension);
+                else
+                {
+                    if (entry.WorkingSource.Length == 0)
+                        continue;
+
+                    string ext = FileFilters.GetDefaultExportAllExtension(entry.GetType());
+                    string path = Path.Combine(outFolder, entry.Name + ext);
+
+                    if (directChildrenExportedPaths.Contains(path))
+                        throw new Exception($"There is more than one node underneath {this.Name} with the name {entry.Name}.");
+                    else
+                    {
+                        directChildrenExportedPaths.Add(path);
+                        entry.Export(path);
+                    }
+                }
+            }
         }
     }
 

--- a/BrawlLib/System/Windows/Forms/ExportAllAskFormat.cs
+++ b/BrawlLib/System/Windows/Forms/ExportAllAskFormat.cs
@@ -9,8 +9,29 @@ namespace System.Windows.Forms
             InitializeComponent();
             string[] source = FileFilters.TEX0.Split('|');
             for (int i = 0; i < source.Length; i += 2)
+            {
+                if (source[i] == "NW4R Texture (*.tex0)")
+                    comboBox1.Items.Add(new FormatForExportAllDialog("NW4R Texture (*.tex0 / *.plt0)", source[i + 1]));
+                else if (!source[i].StartsWith("All"))
+                    comboBox1.Items.Add(new FormatForExportAllDialog(source[i], source[i + 1]));
+            }
+            comboBox1.SelectedIndex = 0;
+        }
+
+        public ExportAllFormatDialog(bool isModels)
+        {
+            if (!isModels)
+            {
+                return;
+            }
+            InitializeComponent();
+            this.label1.Text = "Output format for models:";
+            string[] source = FileFilters.MDL0Export.Split('|');
+            for (int i = 0; i < source.Length; i += 2)
+            {
                 if (!source[i].StartsWith("All"))
                     comboBox1.Items.Add(new FormatForExportAllDialog(source[i], source[i + 1]));
+            }
             comboBox1.SelectedIndex = 0;
         }
 


### PR DESCRIPTION
Fixes #200 and adds requested feature from + fixes #196 

- Extracting All from an ARC now asks for texture/model formats if it has any
- Extracting All from a BRRES now asks for model formats (as well as texture) if it has any
- Extracting All from a U8 or U8Folder no longer crashes the program
- Extracting All from a node with a Null name no longer crashes the program
- Exporting textures in a format other than TEX0 no longer exports associated PLT0s