### PR TITLE
Multiple fixes/improvements

### DIFF
--- a/BrawlBox/BrawlBox.csproj
+++ b/BrawlBox/BrawlBox.csproj
@@ -166,6 +166,7 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="NodeWrappers\ClassicStageTblWrapper.cs" />

--- a/BrawlBox/Properties/AssemblyInfo.cs
+++ b/BrawlBox/Properties/AssemblyInfo.cs
@@ -26,6 +26,9 @@ Super Smash Bros. Brawl © 2008 Nintendo and HAL Laboratory")]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("aa25c3c0-9c54-4fd2-81bc-96efb4953a7b")]
 
+// This prevents resizes on monitors with different DPIs
+[assembly: System.Windows.Media.DisableDpiAwareness]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version

--- a/BrawlBox/UI/Model Previewer/ModelEditControl/MiscFunctions.cs
+++ b/BrawlBox/UI/Model Previewer/ModelEditControl/MiscFunctions.cs
@@ -106,12 +106,12 @@ namespace System.Windows.Forms
         public void CheckDimensions()
         {
             int totalWidth = animEditors.Width;
-            Size s = new Size(animCtrlPnl.Width, animEditors.Height);
+            Drawing.Size s = new Drawing.Size(animCtrlPnl.Width, animEditors.Height);
             if (_currentControl != null && _currentControl.Visible)
             {
                 s = _currentControl.Visible ?
                     (_currentControl is SCN0Editor ? scn0Editor.GetDimensions() : _currentControl.MinimumSize) :
-                    (!weightEditor.Visible && !vertexEditor.Visible ? new Size(0, 0) : s);
+                    (!weightEditor.Visible && !vertexEditor.Visible ? new Drawing.Size(0, 0) : s);
             }
             else if (!weightEditor.Visible && !vertexEditor.Visible)
                 s = new Drawing.Size(0, 0);

--- a/BrawlLib/Modeling/Collada/ColladaExporter.cs
+++ b/BrawlLib/Modeling/Collada/ColladaExporter.cs
@@ -430,7 +430,11 @@ namespace BrawlLib.Modeling
 
             HashSet<Vector3> list = new HashSet<Vector3>();
             for (int i = 0; i < p._pointCount; i++)
-                list.Add(p._vertices[pIndex[i]].GetMatrix().GetRotationMatrix() * pData[i]);
+                if(pIndex[i] != null && p._vertices.Count > pIndex[i] && pData[i] != null)
+                    list.Add(p._vertices[pIndex[i]].GetMatrix().GetRotationMatrix() * pData[i]);
+
+            if (list.Count <= 0)
+                return; // No normals to write; This likely should never happen, but prevents crashes if it does
 
             _normals = new Vector3[list.Count];
             list.CopyTo(_normals);
@@ -438,7 +442,8 @@ namespace BrawlLib.Modeling
             int count = _normals.Length;
             _normRemap = new List<int>();
             for (int i = 0; i < p._pointCount; i++)
-                _normRemap.Add(Array.IndexOf(_normals, p._vertices[pIndex[i]].GetMatrix().GetRotationMatrix() * pData[i]));
+                if(p._vertices.Count > pIndex[i])
+                    _normRemap.Add(Array.IndexOf(_normals, p._vertices[pIndex[i]].GetMatrix().GetRotationMatrix() * pData[i]));
 
             //Position source
             writer.WriteStartElement("source");

--- a/BrawlLib/Modeling/Collada/ColladaImporter.cs
+++ b/BrawlLib/Modeling/Collada/ColladaImporter.cs
@@ -57,271 +57,297 @@ namespace BrawlLib.Modeling
 
             Error = "There was a problem reading the model.";
             using (DecoderShell shell = DecoderShell.Import(filePath))
-            try
-            {
-                Error = "There was a problem reading texture entries.";
-
-                //Extract images, removing duplicates
-                foreach (ImageEntry img in shell._images)
+                try
                 {
-                    string name = img._path != null ? 
-                        Path.GetFileNameWithoutExtension(img._path) :
-                        img._name != null ? img._name : img._id;
+                    Error = "There was a problem reading texture entries.";
 
+                    //Extract images, removing duplicates
+                    foreach (ImageEntry img in shell._images)
+                    {
+                        string name = img._path != null ? 
+                            Path.GetFileNameWithoutExtension(img._path) :
+                            img._name != null ? img._name : img._id;
+
+                        switch (type)
+                        {
+                            case ImportType.MDL0:
+                                img._node = ((MDL0Node)model).FindOrCreateTexture(name);
+                                break;
+                        }
+                    }
+
+                    Error = "There was a problem creating a default shader.";
+
+                    //Create a shader
+                    ResourceNode shader = null;
                     switch (type)
                     {
                         case ImportType.MDL0:
-                            img._node = ((MDL0Node)model).FindOrCreateTexture(name);
+                            MDL0Node m = (MDL0Node)model;
+                            MDL0ShaderNode shadNode = new MDL0ShaderNode()
+                            {
+                                _ref0 = 0,
+                                _ref1 = -1,
+                                _ref2 = -1,
+                                _ref3 = -1,
+                                _ref4 = -1,
+                                _ref5 = -1,
+                                _ref6 = -1,
+                                _ref7 = -1,
+                            };
+
+                            shadNode._parent = m._shadGroup;
+                            m._shadList.Add(shadNode);
+
+                            switch (_importOptions._mdlType)
+                            {
+                                case ImportOptions.MDLType.Character:
+                                    for (int i = 0; i < 3; i++)
+                                    {
+                                        switch (i)
+                                        {
+                                            case 0:
+                                                shadNode.AddChild(new MDL0TEVStageNode(0x28F8AF, 0x08F2F0, 0, TevKColorSel.ConstantColor0_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap0, TexCoordID.TexCoord0, ColorSelChan.LightChannel0, true));
+                                                break;
+                                            case 1:
+                                                shadNode.AddChild(new MDL0TEVStageNode(0x08FEB0, 0x081FF0, 0, TevKColorSel.ConstantColor1_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap7, TexCoordID.TexCoord7, ColorSelChan.LightChannel0, false));
+                                                break;
+                                            case 2:
+                                                shadNode.AddChild(new MDL0TEVStageNode(0x0806EF, 0x081FF0, 0, TevKColorSel.ConstantColor0_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap7, TexCoordID.TexCoord7, ColorSelChan.Zero, false));
+                                                break;
+                                        }
+                                    }
+                                    break;
+                                case ImportOptions.MDLType.Stage:
+                                    shadNode.AddChild(new MDL0TEVStageNode(0x28F8AF, 0x08F2F0, 0, TevKColorSel.ConstantColor0_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap0, TexCoordID.TexCoord0, ColorSelChan.LightChannel0, true));
+                                    break;
+                            }
+
+                            shader = shadNode;
+
                             break;
                     }
-                }
 
-                Error = "There was a problem creating a default shader.";
+                    Error = "There was a problem extracting materials.";
+                    
+                    //Extract materials
+                    foreach (MaterialEntry mat in shell._materials)
+                    {
+                        List<int> uwrap = new List<int>();
+                        List<int> vwrap = new List<int>();
+                        List<int> minfilter = new List<int>();
+                        List<int> magfilter = new List<int>();
+                        List<ImageEntry> imgEntries = new List<ImageEntry>();
 
-                //Create a shader
-                ResourceNode shader = null;
-                switch (type)
-                {
-                    case ImportType.MDL0:
-                        MDL0Node m = (MDL0Node)model;
-                        MDL0ShaderNode shadNode = new MDL0ShaderNode()
+                        //Find effect
+                        if (mat._effect != null)
+                            foreach (EffectEntry eff in shell._effects)
+                                if (eff._id == mat._effect) //Attach textures and effects to material
+                                    if (eff._shader != null)
+                                        foreach (LightEffectEntry l in eff._shader._effects)
+                                            if (l._type == LightEffectType.diffuse && l._texture != null)
+                                            {
+                                                string path = l._texture;
+                                                foreach (EffectNewParam p in eff._newParams)
+                                                {
+                                                    if (p._sampler2D != null || p._sid == l._texture)
+                                                    {
+                                                        path = p._sampler2D._url;
+                                                        if (!String.IsNullOrEmpty(p._sampler2D._source))
+                                                            foreach (EffectNewParam p2 in eff._newParams)
+                                                                if (p2._sid == p._sampler2D._source)
+                                                                    path = p2._path;
+                                                        switch (p._sampler2D._wrapS)
+                                                        {
+                                                            case "CLAMP":
+                                                                uwrap.Add(0);
+                                                                break;
+                                                            case "WRAP":
+                                                                uwrap.Add(1);
+                                                                break;
+                                                            case "MIRROR":
+                                                                uwrap.Add(2);
+                                                                break;
+                                                            default:
+                                                                uwrap.Add(0);
+                                                                break;
+                                                        }
+                                                        switch (p._sampler2D._wrapT)
+                                                        {
+                                                            case "CLAMP":
+                                                                vwrap.Add(0);
+                                                                break;
+                                                            case "WRAP":
+                                                                vwrap.Add(1);
+                                                                break;
+                                                            case "MIRROR":
+                                                                vwrap.Add(2);
+                                                                break;
+                                                            default:
+                                                                vwrap.Add(0);
+                                                                break;
+                                                        }
+                                                        switch (p._sampler2D._minFilter)
+                                                        {
+                                                            case "NEAREST":
+                                                                minfilter.Add(0);
+                                                                break;
+                                                            case "LINEAR":
+                                                                minfilter.Add(1);
+                                                                break;
+                                                            case "NEAREST_MIPMAP_NEAREST":
+                                                                minfilter.Add(2);
+                                                                break;
+                                                            case "LINEAR_MIPMAP_NEAREST":
+                                                                minfilter.Add(3);
+                                                                break;
+                                                            case "NEAREST_MIPMAP_LINEAR":
+                                                                minfilter.Add(4);
+                                                                break;
+                                                            case "LINEAR_MIPMAP_LINEAR":
+                                                                minfilter.Add(5);
+                                                                break;
+                                                            default:
+                                                                minfilter.Add(0);
+                                                                break;
+                                                        }
+                                                        switch (p._sampler2D._magFilter)
+                                                        {
+                                                            case "NEAREST":
+                                                                magfilter.Add(0);
+                                                                break;
+                                                            case "LINEAR":
+                                                                magfilter.Add(1);
+                                                                break;
+                                                            case "NEAREST_MIPMAP_NEAREST":
+                                                                magfilter.Add(2);
+                                                                break;
+                                                            case "LINEAR_MIPMAP_NEAREST":
+                                                                magfilter.Add(3);
+                                                                break;
+                                                            case "NEAREST_MIPMAP_LINEAR":
+                                                                magfilter.Add(4);
+                                                                break;
+                                                            case "LINEAR_MIPMAP_LINEAR":
+                                                                magfilter.Add(5);
+                                                                break;
+                                                            default:
+                                                                magfilter.Add(0);
+                                                                break;
+                                                        }
+                                                        foreach (ImageEntry img in shell._images)
+                                                            if (img._id == path)
+                                                            {
+                                                                imgEntries.Add(img);
+                                                                break;
+                                                            }
+                                                    }
+                                                }
+                                            }
+                        switch (type)
                         {
-                            _ref0 = 0,
-                            _ref1 = -1,
-                            _ref2 = -1,
-                            _ref3 = -1,
-                            _ref4 = -1,
-                            _ref5 = -1,
-                            _ref6 = -1,
-                            _ref7 = -1,
-                        };
+                            case ImportType.MDL0:
+                                MDL0MaterialNode matNode = new MDL0MaterialNode();
 
-                        shadNode._parent = m._shadGroup;
-                        m._shadList.Add(shadNode);
+                                MDL0Node m = (MDL0Node)model;
+                                matNode._parent = m._matGroup;
+                                m._matList.Add(matNode);
 
-                        switch (_importOptions._mdlType)
-                        {
-                            case ImportOptions.MDLType.Character:
-                                for (int i = 0; i < 3; i++)
+                                matNode._name = mat._name != null ? mat._name : mat._id;
+                                matNode.ShaderNode = shader as MDL0ShaderNode;
+
+                                mat._node = matNode;
+                                matNode._cull = _importOptions._culling;
+
+                                int i = 0;
+                                foreach (ImageEntry img in imgEntries)
                                 {
-                                    switch (i)
-                                    {
-                                        case 0:
-                                            shadNode.AddChild(new MDL0TEVStageNode(0x28F8AF, 0x08F2F0, 0, TevKColorSel.ConstantColor0_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap0, TexCoordID.TexCoord0, ColorSelChan.LightChannel0, true));
-                                            break;
-                                        case 1:
-                                            shadNode.AddChild(new MDL0TEVStageNode(0x08FEB0, 0x081FF0, 0, TevKColorSel.ConstantColor1_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap7, TexCoordID.TexCoord7, ColorSelChan.LightChannel0, false));
-                                            break;
-                                        case 2:
-                                            shadNode.AddChild(new MDL0TEVStageNode(0x0806EF, 0x081FF0, 0, TevKColorSel.ConstantColor0_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap7, TexCoordID.TexCoord7, ColorSelChan.Zero, false));
-                                            break;
-                                    }
+                                    MDL0MaterialRefNode mr = new MDL0MaterialRefNode();
+                                    (mr._texture = img._node as MDL0TextureNode)._references.Add(mr);
+                                    mr._name = mr._texture.Name;
+                                    matNode._children.Add(mr);
+                                    mr._parent = matNode;
+                                    mr._minFltr = minfilter[i];
+                                    mr._magFltr = magfilter[i];
+                                    mr._uWrap = uwrap[i];
+                                    mr._vWrap = vwrap[i];
+                                    i++;
                                 }
                                 break;
-                            case ImportOptions.MDLType.Stage:
-                                shadNode.AddChild(new MDL0TEVStageNode(0x28F8AF, 0x08F2F0, 0, TevKColorSel.ConstantColor0_RGB, TevKAlphaSel.ConstantColor0_Alpha, TexMapID.TexMap0, TexCoordID.TexCoord0, ColorSelChan.LightChannel0, true));
+                        }
+                    }
+
+                    Say("Extracting scenes...");
+
+                    List<ObjectInfo> _objects = new List<ObjectInfo>();
+                    ResourceNode boneGroup = null;
+                    switch (type)
+                    {
+                        case ImportType.MDL0:
+                            boneGroup = ((MDL0Node)model)._boneGroup;
+                            break;
+                    }
+
+                    //Extract bones and objects and create bone tree
+                    foreach (SceneEntry scene in shell._scenes)
+                        foreach (NodeEntry node in scene._nodes)
+                            EnumNode(node, boneGroup, scene, model, shell, _objects, TransformMatrix, Matrix.Identity);
+
+                    //Add root bone if there are no bones
+                    if (boneGroup.Children.Count == 0)
+                        switch (type)
+                        {
+                            case ImportType.MDL0:
+                                MDL0BoneNode bone = new MDL0BoneNode();
+                                bone.Scale = new Vector3(1);
+                                bone.RecalcBindState(false, false);
+                                bone._name = "TopN";
+                                TempRootBone = bone;
                                 break;
                         }
 
-                        shader = shadNode;
+                    //Create objects
+                    foreach (ObjectInfo obj in _objects)
+                    {
+                        NodeEntry node = obj._node;
+                        string w = obj._weighted ? "" : "un";
+                        string w2 = obj._weighted ? "\nOne or more vertices may not be weighted correctly." : "";
+                        string n = node._name != null ? node._name : node._id;
 
-                        break;
-                }
+                        Error = String.Format("There was a problem decoding {0}weighted primitives for the object {1}.{2}", w, n, w2);
 
-                Error = "There was a problem extracting materials.";
+                        Say(String.Format("Decoding {0}weighted primitives for {1}...", w, n));
 
-                int uwrap = 1;
-                int vwrap = 1;
-                int minfilter = 1;
-                int magfilter = 1;
+                        obj.Initialize(model, shell);
+                    }
 
-                //Extract materials
-                foreach (MaterialEntry mat in shell._materials)
-                {
-                    List<ImageEntry> imgEntries = new List<ImageEntry>();
-
-                    //Find effect
-                    if (mat._effect != null)
-                        foreach (EffectEntry eff in shell._effects)
-                            if (eff._id == mat._effect) //Attach textures and effects to material
-                                if (eff._shader != null)
-                                    foreach (LightEffectEntry l in eff._shader._effects)
-                                        if (l._type == LightEffectType.diffuse && l._texture != null)
-                                        {
-                                            string path = l._texture;
-                                            foreach (EffectNewParam p in eff._newParams)
-                                                if (p._sid == l._texture)
-                                                {
-                                                    path = p._sampler2D._url;
-                                                    if (!String.IsNullOrEmpty(p._sampler2D._source))
-                                                        foreach (EffectNewParam p2 in eff._newParams)
-                                                            if (p2._sid == p._sampler2D._source)
-                                                                path = p2._path;
-                                                    switch (p._sampler2D._wrapS)
-                                                    {
-                                                        case "CLAMP":
-                                                            uwrap = 0;
-                                                            break;
-                                                        case "WRAP":
-                                                            uwrap = 1;
-                                                            break;
-                                                        case "MIRROR":
-                                                            uwrap = 2;
-                                                            break;
-                                                    }
-                                                    switch (p._sampler2D._wrapT)
-                                                    {
-                                                        case "CLAMP":
-                                                            vwrap = 0;
-                                                            break;
-                                                        case "WRAP":
-                                                            vwrap = 1;
-                                                            break;
-                                                        case "MIRROR":
-                                                            vwrap = 2;
-                                                            break;
-                                                    }
-                                                    switch (p._sampler2D._minFilter)
-                                                    {
-                                                        case "NEAREST":
-                                                            minfilter = 0;
-                                                            break;
-                                                        case "LINEAR":
-                                                            minfilter = 1;
-                                                            break;
-                                                        case "NEAREST_MIPMAP_NEAREST":
-                                                            minfilter = 2;
-                                                            break;
-                                                        case "LINEAR_MIPMAP_NEAREST":
-                                                            minfilter = 3;
-                                                            break;
-                                                        case "NEAREST_MIPMAP_LINEAR":
-                                                            minfilter = 4;
-                                                            break;
-                                                        case "LINEAR_MIPMAP_LINEAR":
-                                                            minfilter = 5;
-                                                            break;
-                                                     }
-                                                     switch (p._sampler2D._magFilter)
-                                                     {
-                                                        case "NEAREST":
-                                                            magfilter = 0;
-                                                            break;
-                                                        case "LINEAR":
-                                                            magfilter = 1;
-                                                            break;
-                                                     }
-                                                }
-
-                                            foreach (ImageEntry img in shell._images)
-                                                if (img._id == path)
-                                                {
-                                                    imgEntries.Add(img);
-                                                    break;
-                                                }
-                                        }
+                    //Finish
                     switch (type)
                     {
                         case ImportType.MDL0:
-                            MDL0MaterialNode matNode = new MDL0MaterialNode();
-
-                            MDL0Node m = (MDL0Node)model;
-                            matNode._parent = m._matGroup;
-                            m._matList.Add(matNode);
-
-                            matNode._name = mat._name != null ? mat._name : mat._id;
-                            matNode.ShaderNode = shader as MDL0ShaderNode;
-
-                            mat._node = matNode;
-                            matNode._cull = _importOptions._culling;
-
-                            foreach (ImageEntry img in imgEntries)
+                            MDL0Node mdl0 = (MDL0Node)model;
+                            if (TempRootBone != null)
                             {
-                                MDL0MaterialRefNode mr = new MDL0MaterialRefNode();
-                                (mr._texture = img._node as MDL0TextureNode)._references.Add(mr);
-                                mr._name = mr._texture.Name;
-                                matNode._children.Add(mr);
-                                mr._parent = matNode;
-                                mr._minFltr = minfilter;
-                                mr._magFltr = magfilter;
-                                mr._uWrap = uwrap;
-                                mr._vWrap = vwrap;
+                                mdl0._boneGroup._children.Add(TempRootBone);
+                                TempRootBone._parent = mdl0._boneGroup;
                             }
+                            FinishMDL0(mdl0);
                             break;
                     }
                 }
-
-                Say("Extracting scenes...");
-
-                List<ObjectInfo> _objects = new List<ObjectInfo>();
-                ResourceNode boneGroup = null;
-                switch (type)
+    #if !DEBUG
+                catch (Exception x)
                 {
-                    case ImportType.MDL0:
-                        boneGroup = ((MDL0Node)model)._boneGroup;
-                        break;
+                    MessageBox.Show("Cannot continue importing this model.\n" + Error + "\n\nException:\n" + x.ToString());
+                    model = null;
+                    Close();
                 }
-
-                //Extract bones and objects and create bone tree
-                foreach (SceneEntry scene in shell._scenes)
-                    foreach (NodeEntry node in scene._nodes)
-                        EnumNode(node, boneGroup, scene, model, shell, _objects, TransformMatrix, Matrix.Identity);
-
-                //Add root bone if there are no bones
-                if (boneGroup.Children.Count == 0)
-                    switch (type)
-                    {
-                        case ImportType.MDL0:
-                            MDL0BoneNode bone = new MDL0BoneNode();
-                            bone.Scale = new Vector3(1);
-                            bone.RecalcBindState(false, false);
-                            bone._name = "TopN";
-                            TempRootBone = bone;
-                            break;
-                    }
-
-                //Create objects
-                foreach (ObjectInfo obj in _objects)
+    #endif
+                finally
                 {
-                    NodeEntry node = obj._node;
-                    string w = obj._weighted ? "" : "un";
-                    string w2 = obj._weighted ? "\nOne or more vertices may not be weighted correctly." : "";
-                    string n = node._name != null ? node._name : node._id;
-
-                    Error = String.Format("There was a problem decoding {0}weighted primitives for the object {1}.{2}", w, n, w2);
-
-                    Say(String.Format("Decoding {0}weighted primitives for {1}...", w, n));
-
-                    obj.Initialize(model, shell);
+                    //Clean up the mess we've made
+                    GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
                 }
-
-                //Finish
-                switch (type)
-                {
-                    case ImportType.MDL0:
-                        MDL0Node mdl0 = (MDL0Node)model;
-                        if (TempRootBone != null)
-                        {
-                            mdl0._boneGroup._children.Add(TempRootBone);
-                            TempRootBone._parent = mdl0._boneGroup;
-                        }
-                        FinishMDL0(mdl0);
-                        break;
-                }
-            }
-#if !DEBUG
-            catch (Exception x)
-            {
-                MessageBox.Show("Cannot continue importing this model.\n" + Error + "\n\nException:\n" + x.ToString());
-                model = null;
-                Close();
-            }
-#endif
-            finally
-            {
-                //Clean up the mess we've made
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced);
-            }
 
             CurrentModel = null;
             Error = null;
@@ -688,9 +714,9 @@ namespace BrawlLib.Modeling
             public float WeightPrecision { get { return _weightPrecision; } set { _weightPrecision = value.Clamp(0.0000001f, 0.999999f); } }
             [Category("Model"), Description("Sets the model version number, which affects how some parts of the model are written. Only versions 8, 9, 10 and 11 are supported.")]
             public int ModelVersion { get { return _modelVersion; } set { _modelVersion = value.Clamp(8, 11); } }
-            //[Category("Model"), TypeConverter(typeof(Vector3StringConverter)), Description("Rotates the entire model before importing. This can be used to fix a model's up axis, as BrawlBox uses Y-up while some other 3D programs use Z-up.")]
+            //[Category("Model"), TypeConverter(typeof(Vector3StringConverter)), Description("Rotates the entire model before importing. This can be used to fix a model's up axis, as BrawlCrate uses Y-up while some other 3D programs use Z-up.")]
             //public Vector3 ModifyRotation { get { return _modifyRotation; } set { _modifyRotation = value; } }
-            //[Category("Model"), TypeConverter(typeof(Vector3StringConverter)), Description("Scales the entire model before importing. This can be used to fix a model's units, as BrawlBox uses centimeters while other 3D programs uses units such as meters or inches.")]
+            //[Category("Model"), TypeConverter(typeof(Vector3StringConverter)), Description("Scales the entire model before importing. This can be used to fix a model's units, as BrawlCrate uses centimeters while other 3D programs uses units such as meters or inches.")]
             //public Vector3 ModifyScale { get { return _modifyScale; } set { _modifyScale = value; } }
             
             [Category("Materials"), Description("If true, materials will be remapped. This means there will be no redundant materials with the same settings, saving file space.")]

--- a/BrawlLib/Properties/AssemblyInfo.cs
+++ b/BrawlLib/Properties/AssemblyInfo.cs
@@ -21,6 +21,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("84b5ec46-630b-4225-beec-6082c28f85e6")]
 
+// This prevents resizes on monitors with different DPIs
+[assembly: System.Windows.Media.DisableDpiAwareness]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version

--- a/BrawlLib/System/Windows/Forms/TextureConverterDialog.cs
+++ b/BrawlLib/System/Windows/Forms/TextureConverterDialog.cs
@@ -289,9 +289,9 @@ namespace System.Windows.Forms
         public bool LoadImages(string path)
         {
             txtPath.Text = path;
-            if (path.EndsWith(".tga"))
+            if (path.EndsWith(".tga", StringComparison.OrdinalIgnoreCase))
                 return LoadImages(TGA.FromFile(path));
-            else if (path.EndsWith(".png"))
+            else if (path.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
                 return LoadImagesPreservingPaletteInfo(path);
             else
                 return LoadImages((Bitmap)Bitmap.FromFile(path));

--- a/Ikarus/Properties/AssemblyInfo.cs
+++ b/Ikarus/Properties/AssemblyInfo.cs
@@ -27,6 +27,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3a58aa6c-1b11-4e61-af15-51b70da5035a")]
 
+// This prevents resizes on monitors with different DPIs
+[assembly: System.Windows.Media.DisableDpiAwareness]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version

--- a/Updater/Net.csproj
+++ b/Updater/Net.csproj
@@ -102,6 +102,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Updater/Properties/AssemblyInfo.cs
+++ b/Updater/Properties/AssemblyInfo.cs
@@ -22,6 +22,9 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ee562171-2908-40ce-ba2d-35ff76fe9055")]
 
+// This prevents resizes on monitors with different DPIs
+[assembly: System.Windows.Media.DisableDpiAwareness]
+
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version


### PR DESCRIPTION
- Fixes DPI-based resize bug (Fixes #194 's second issue)
- Adds support for import/export of multiple subtextures for each material from DAE files
- Fixes export of old MDL0's with bad normals as DAE (Fixes https://github.com/StageBoxBrawl/StageBoxIssues/issues/17 )
- Fixes issue where .tga files would not import correctly if they used a different case on the extension (IE .TGA)
- Fixes issue where only pngs with the exact, case-sensitive extension of ".png" would correctly import with palettes