### PR TITLE
Alt key no longer lags model viewer

### DIFF
--- a/BrawlLib/SSBB/ResourceNodes/MDL0/MDL0ObjectNode.cs
+++ b/BrawlLib/SSBB/ResourceNodes/MDL0/MDL0ObjectNode.cs
@@ -1115,7 +1115,7 @@ namespace BrawlLib.SSBB.ResourceNodes
                     AlphaTest(material);
                 else
                 {
-                    material.UseProgram(this, Control.ModifierKeys == Keys.Alt);
+                    material.UseProgram(this);
                     Blend(material);
                 }
 


### PR DESCRIPTION
Old behavior caused MDL0 Objects to completely rebuild their materials on every render call if the Alt key (but not shift or control) is pressed. This caused major lag when using shortcuts like new collision creation in the collision editor. The functionality offered by rebuilding materials every frame when alt is pressed is not particularly useful and should just be removed outright.

Here's a comparison of before and after the fix:
Before: https://gfycat.com/EmbellishedAnyGalapagosdove
After: https://gfycat.com/OnlyOddEastrussiancoursinghounds